### PR TITLE
Refactor JenkinsConnector to allow builds from ci-dev to be saved

### DIFF
--- a/app/uk/gov/hmrc/repositoryjobs/JenkinsConnector.scala
+++ b/app/uk/gov/hmrc/repositoryjobs/JenkinsConnector.scala
@@ -79,7 +79,7 @@ trait JenkinsConnector {
               .validate[JenkinsJobsResponse]) match {
             case Success(jsResult) => jsResult
             case Failure(t)        => JsError(t.getMessage)
-          })
+        })
 
     result.map {
       case JsSuccess(jenkinsResponse, _) =>
@@ -91,13 +91,15 @@ trait JenkinsConnector {
 }
 
 @Singleton
-class JenkinsCiDevConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig) extends JenkinsConnector {
-  override val host: String = repositoryJobsConfig.ciDevUrl
+class JenkinsCiDevConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)
+    extends JenkinsConnector {
+  override val host: String     = repositoryJobsConfig.ciDevUrl
   override val http: HttpClient = httpClient
 }
 
 @Singleton
-class JenkinsCiOpenConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig) extends JenkinsConnector {
-  override val host: String = repositoryJobsConfig.ciOpenUrl
+class JenkinsCiOpenConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)
+    extends JenkinsConnector {
+  override val host: String     = repositoryJobsConfig.ciOpenUrl
   override val http: HttpClient = httpClient
 }

--- a/app/uk/gov/hmrc/repositoryjobs/RepositoryJobsService.scala
+++ b/app/uk/gov/hmrc/repositoryjobs/RepositoryJobsService.scala
@@ -29,10 +29,10 @@ import scala.util.control.NonFatal
 
 @Singleton
 class RepositoryJobsService @Inject()(
-                                       repository: BuildsRepository,
-                                       jenkinsDevConnector: JenkinsCiDevConnector,
-                                       jenkinsOpenConnector: JenkinsCiOpenConnector,
-                                       repositoryJobsConfig: RepositoryJobsConfig) {
+  repository: BuildsRepository,
+  jenkinsDevConnector: JenkinsCiDevConnector,
+  jenkinsOpenConnector: JenkinsCiOpenConnector,
+  repositoryJobsConfig: RepositoryJobsConfig) {
 
   def key(jobName: String, timestamp: Long): String =
     s"${jobName}_$timestamp"
@@ -55,10 +55,12 @@ class RepositoryJobsService @Inject()(
       _ = Logger.info(s"Fetched existing repositories from mongo.  Number of existing builds: ${existingBuilds.size}")
 
       newBuildsFromDev = getBuilds(devBuildsResponse.jobs, existingBuilds)
-      _ = Logger.info(s"Calculated new builds to be saved from jenkins ci-dev. Number of new builds: ${newBuildsFromDev.size}")
+      _ = Logger.info(
+        s"Calculated new builds to be saved from jenkins ci-dev. Number of new builds: ${newBuildsFromDev.size}")
 
       newBuildsFromOpen = getBuilds(openBuildsResponse.jobs, existingBuilds)
-      _ = Logger.info(s"Calculated new builds to be saved from jenkins ci-open. Number of new builds: ${newBuildsFromOpen.size}")
+      _ = Logger.info(
+        s"Calculated new builds to be saved from jenkins ci-open. Number of new builds: ${newBuildsFromOpen.size}")
 
       result <- repository.bulkAdd(newBuildsFromDev ++ newBuildsFromOpen)
     } yield result)

--- a/app/uk/gov/hmrc/repositoryjobs/config/RepositoryJobsConfig.scala
+++ b/app/uk/gov/hmrc/repositoryjobs/config/RepositoryJobsConfig.scala
@@ -25,9 +25,11 @@ class RepositoryJobsConfig @Inject()(configuration: Configuration) {
   val schedulerEnabled =
     configuration.getBoolean("scheduler.enabled").getOrElse(false)
 
-  private val jobsApiUrlConfigKey = "jobs.api.url"
-  lazy val jobsApiBase: String = config(jobsApiUrlConfigKey).getOrElse(
-    throw new RuntimeException(s"Error getting config value for $jobsApiUrlConfigKey."))
+  def ciDevUrl: String = config("jobs.api.url.ci-dev").getOrElse(
+    throw new RuntimeException("Error getting config value jobs.api.url.ci-dev"))
+
+  def ciOpenUrl: String = config("jobs.api.url.ci-open").getOrElse(
+    throw new RuntimeException("Error getting config value jobs.api.url.ci-open"))
 
   private def config(path: String) = configuration.getString(s"$path")
 

--- a/app/uk/gov/hmrc/repositoryjobs/config/RepositoryJobsConfig.scala
+++ b/app/uk/gov/hmrc/repositoryjobs/config/RepositoryJobsConfig.scala
@@ -25,11 +25,13 @@ class RepositoryJobsConfig @Inject()(configuration: Configuration) {
   val schedulerEnabled =
     configuration.getBoolean("scheduler.enabled").getOrElse(false)
 
-  def ciDevUrl: String = config("jobs.api.url.ci-dev").getOrElse(
-    throw new RuntimeException("Error getting config value jobs.api.url.ci-dev"))
+  def ciDevUrl: String =
+    config("jobs.api.url.ci-dev").getOrElse(
+      throw new RuntimeException("Error getting config value jobs.api.url.ci-dev"))
 
-  def ciOpenUrl: String = config("jobs.api.url.ci-open").getOrElse(
-    throw new RuntimeException("Error getting config value jobs.api.url.ci-open"))
+  def ciOpenUrl: String =
+    config("jobs.api.url.ci-open").getOrElse(
+      throw new RuntimeException("Error getting config value jobs.api.url.ci-open"))
 
   private def config(path: String) = configuration.getString(s"$path")
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -169,6 +169,11 @@ microservice {
     }
 }
 
+jobs.api.url {
+    ci-dev = ""
+    ci-open = ""
+}
+
 scheduler.enabled = true
 
 auditing.enabled = false

--- a/test/uk/gov/hmrc/repositoryjobs/JenkinsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/repositoryjobs/JenkinsConnectorSpec.scala
@@ -41,8 +41,8 @@ class JenkinsConnectorSpec
 
     "Deserialise the response upon a successful request" in {
 
-      val connector = new JenkinsConnector(app.injector.instanceOf[HttpClient], mock[RepositoryJobsConfig]) {
-        override def jenkinsBaseUrl: String = endpointMockUrl
+      val connector = new JenkinsCiDevConnector(app.injector.instanceOf[HttpClient], mock[RepositoryJobsConfig]) {
+        override val host: String = endpointMockUrl
       }
 
       serviceEndpoint(GET, connector.buildsUrl, willRespondWith = (200, Some(JsonData.jenkinsJobsResponse)))
@@ -72,8 +72,8 @@ class JenkinsConnectorSpec
 
     "handle control characters in the response body" in {
 
-      val connector = new JenkinsConnector(app.injector.instanceOf[HttpClient], mock[RepositoryJobsConfig]) {
-        override def jenkinsBaseUrl: String = endpointMockUrl
+      val connector = new JenkinsCiDevConnector(app.injector.instanceOf[HttpClient], mock[RepositoryJobsConfig]) {
+        override val host: String = endpointMockUrl
       }
 
       serviceEndpoint(

--- a/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsServiceSpec.scala
+++ b/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsServiceSpec.scala
@@ -24,10 +24,12 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{BeforeAndAfterEach, GivenWhenThen, Matchers, WordSpec}
 import play.modules.reactivemongo.ReactiveMongoComponent
+import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
+import uk.gov.hmrc.repositoryjobs.config.RepositoryJobsConfig
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import uk.gov.hmrc.mongo.{MongoConnector, MongoSpecSupport}
 
 class RepositoryJobsServiceSpec
     extends WordSpec
@@ -37,197 +39,130 @@ class RepositoryJobsServiceSpec
     with MongoSpecSupport
     with BeforeAndAfterEach
     with GivenWhenThen
-    with PropertyChecks {
+    with PropertyChecks
+    with WireMockEndpoints {
 
   "Repository jobs service" should {
-    "An empty list is returned when there are no new builds" in {
+    "return an empty list when there are no new builds" in {
       forAll(genJobsWithNoNewBuilds) {
         case (jobs, builds) =>
           repositoryJobsService.getBuilds(jobs, builds).size shouldBe 0
       }
     }
 
-    "A list of only the new builds is returned when new builds exist" in {
+    "return a list of only new builds when new builds exist" in {
       forAll(genJobsWithNewBuilds) {
         case (jobs, existingBuilds, numberOfNewBuilds) =>
           repositoryJobsService.getBuilds(jobs, existingBuilds).size shouldBe numberOfNewBuilds
       }
     }
 
-    "Pick only new valid builds to save" in {
-      val repoName = "repoName"
-      val serviceGitConfig =
-        Scm(List(UserRemoteConfig(repoName.some)).some)
-
-      val validBuildResponse =
-        BuildResponse(
-          "description-1".some,
-          218869.some,
-          "123".some,
-          123.some,
-          "SUCCESS".some,
-          1490611944493L.some,
-          "buildurl".some,
-          "builton".some)
-
-      val invalidBuildResponse =
-        BuildResponse(
-          "description-2".some,
-          218869.some,
-          "123".some,
-          123.some,
-          None,
-          1486571225111L.some,
-          "buildurl".some,
-          "builton".some)
-
-      val existingBuildResponse =
-        BuildResponse(
-          "description-3".some,
-          218869.some,
-          "124".some,
-          124.some,
-          "SUCCESS".some,
-          1486571225000L.some,
-          "buildurl".some,
-          "builton".some)
-
-      val jobs =
-        List(
-          Job(
-            name      = "jobName".some,
-            url       = "jobUrl".some,
-            allBuilds = List(validBuildResponse, invalidBuildResponse, existingBuildResponse),
-            scm       = serviceGitConfig.some))
-
-      val existingBuilds =
-        List(
-          Build(
-            repositoryName = "repoName".some,
-            jobName        = "jobName".some,
-            jobUrl         = "jobUrl".some,
-            buildNumber    = existingBuildResponse.number,
-            result         = existingBuildResponse.result,
-            timestamp      = existingBuildResponse.timestamp,
-            duration       = existingBuildResponse.duration,
-            buildUrl       = existingBuildResponse.url,
-            builtOn        = existingBuildResponse.builtOn
-          ))
-
-      repositoryJobsService.getBuilds(jobs, existingBuilds) should contain theSameElementsAs
-        List(
-          Build(
-            repositoryName = "repoName".some,
-            jobName        = "jobName".some,
-            jobUrl         = "jobUrl".some,
-            buildNumber    = validBuildResponse.number,
-            result         = validBuildResponse.result,
-            timestamp      = validBuildResponse.timestamp,
-            duration       = validBuildResponse.duration,
-            buildUrl       = validBuildResponse.url,
-            builtOn        = validBuildResponse.builtOn
-          )
-        )
+    "only save new valid builds" in {
+      repositoryJobsService.getBuilds(jobs, List(existingBuild)) should contain theSameElementsAs
+        List(validBuildDev)
     }
 
-    "Insert valid new builds and return the number of mongo successes and failures" in {
-      val repoName = "repoName"
+    "insert new builds" when {
 
-      val serviceGitConfig =
-        Scm(List(UserRemoteConfig(repoName.some)).some)
+      "ci-dev contains records and ci-open doesn't contain records" in {
 
-      Given("Jenkins returns a mix of valid, invalid and existing builds")
-      val validBuildResponse =
-        BuildResponse(
-          "description-1".some,
-          218869.some,
-          "123".some,
-          123.some,
-          "SUCCESS".some,
-          1490611944493L.some,
-          "buildurl".some,
-          "builton".some)
+        Mockito
+          .when(connectorCiOpen.getBuilds)
+          .thenReturn(
+            Future.successful(
+              JenkinsJobsResponse(List.empty)))
 
-      val invalidBuildResponse =
-        BuildResponse(
-          "description-2".some,
-          218869.some,
-          "123".some,
-          123.some,
-          None,
-          1486571225111L.some,
-          "buildurl".some,
-          "builton".some)
+        And("mongo contains the existing builds")
+        repository.bulkAdd(List(existingBuild)).futureValue
 
-      val existingBuildResponse =
-        BuildResponse(
-          "description-3".some,
-          218869.some,
-          "124".some,
-          124.some,
-          "SUCCESS".some,
-          1486571225000L.some,
-          "buildurl".some,
-          "builton".some)
+        When("we update the builds")
+        val updateResult = repositoryJobsService.update.futureValue
 
-      val serviceBuilds =
-        List(validBuildResponse, invalidBuildResponse, existingBuildResponse)
+        Then("only the new builds are saved")
 
-      val jobName = "jobName"
-      val jobUrl  = "jobUrl"
+        repository.getAll.futureValue should contain theSameElementsAs
+          List(existingBuild, validBuildDev)
 
-      Mockito
-        .when(connector.getBuilds)
-        .thenReturn(
-          Future.successful(
-            JenkinsJobsResponse(List(
-              Job(jobName.some, jobUrl.some, serviceBuilds, serviceGitConfig.some)
-            ))))
+        And("the result should return the number of successes and failures")
+        updateResult.nSuccesses shouldBe 1
+        updateResult.nFailures  shouldBe 0
+      }
 
-      val existingBuild =
-        Build(
-          repositoryName = repoName.some,
-          jobName        = jobName.some,
-          jobUrl         = jobUrl.some,
-          buildNumber    = existingBuildResponse.number,
-          result         = existingBuildResponse.result,
-          timestamp      = existingBuildResponse.timestamp,
-          duration       = existingBuildResponse.duration,
-          buildUrl       = existingBuildResponse.url,
-          builtOn        = existingBuildResponse.builtOn
-        )
+      "ci-open contains records and ci-dev doesn't contain records" in {
 
-      And("mongo contains the existing builds")
-      repository.bulkAdd(List(existingBuild)).futureValue
+        Mockito
+          .when(connectorCiDev.getBuilds)
+          .thenReturn(
+            Future.successful(
+              JenkinsJobsResponse(List.empty)))
 
-      When("we update the builds")
-      val updateResult = repositoryJobsService.update.futureValue
+        And("mongo contains the existing builds")
+        repository.bulkAdd(List(existingBuild)).futureValue
 
-      Then("only the new builds are saved")
-      val validBuild =
-        Build(
-          repositoryName = repoName.some,
-          jobName        = jobName.some,
-          jobUrl         = jobUrl.some,
-          buildNumber    = validBuildResponse.number,
-          result         = validBuildResponse.result,
-          timestamp      = validBuildResponse.timestamp,
-          duration       = validBuildResponse.duration,
-          buildUrl       = validBuildResponse.url,
-          builtOn        = validBuildResponse.builtOn
-        )
+        When("we update the builds")
+        val updateResult = repositoryJobsService.update.futureValue
 
-      repository.getAll.futureValue should contain theSameElementsAs
-        List(existingBuild, validBuild)
+        Then("only the new builds are saved")
 
-      And("the result should return the number of successes and failures")
-      updateResult.nSuccesses shouldBe 1
-      updateResult.nFailures  shouldBe 0
+        repository.getAll.futureValue should contain theSameElementsAs
+          List(existingBuild, validBuildOpen)
+
+        And("the result should return the number of successes and failures")
+        updateResult.nSuccesses shouldBe 1
+        updateResult.nFailures  shouldBe 0
+      }
+
+      "ci-dev and ci-open both contain records" in {
+
+        And("mongo contains the existing builds")
+        repository.bulkAdd(List(existingBuild)).futureValue
+
+        When("we update the builds")
+        val updateResult = repositoryJobsService.update.futureValue
+
+        Then("only the new builds are saved")
+
+        repository.getAll.futureValue should contain theSameElementsAs
+          List(existingBuild, validBuildDev, validBuildOpen)
+
+        And("the result should return the number of successes and failures")
+        updateResult.nSuccesses shouldBe 2
+        updateResult.nFailures  shouldBe 0
+      }
+
     }
+
   }
 
-  override def beforeEach(): Unit =
+  val repoName = "repoName"
+
+  val serviceGitConfig =
+    Scm(List(UserRemoteConfig(repoName.some)).some)
+
+  override def beforeEach(): Unit = {
     repository.drop.futureValue
+
+    Mockito
+      .when(config.ciDevUrl)
+      .thenReturn(endpointMockUrl)
+
+    Mockito
+      .when(connectorCiDev.getBuilds)
+      .thenReturn(
+        Future.successful(
+          JenkinsJobsResponse(List(
+            Job(jobName.some, jobUrl.some, serviceBuildsDev, serviceGitConfig.some)
+          ))))
+
+    Mockito
+      .when(connectorCiOpen.getBuilds)
+      .thenReturn(
+        Future.successful(
+          JenkinsJobsResponse(List(
+            Job(jobName.some, jobUrl.some, serviceBuildsOpen, serviceGitConfig.some)
+          ))))
+  }
+
 
   override implicit val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = 5.seconds)
@@ -236,9 +171,11 @@ class RepositoryJobsServiceSpec
     override def mongoConnector: MongoConnector = mongoConnectorForTest
   })
 
-  val connector: JenkinsConnector = mock[JenkinsConnector]
+  val connectorCiDev: JenkinsCiDevConnector = mock[JenkinsCiDevConnector]
+  val connectorCiOpen: JenkinsCiOpenConnector = mock[JenkinsCiOpenConnector]
+  val config: RepositoryJobsConfig = mock[RepositoryJobsConfig]
 
-  val repositoryJobsService = new RepositoryJobsService(repository, connector)
+  val repositoryJobsService = new RepositoryJobsService(repository, connectorCiDev, connectorCiOpen, config)
 
   case class BuildId(jobName: String, timestamp: Long)
 
@@ -296,4 +233,102 @@ class RepositoryJobsServiceSpec
       existingBuildsAfterDropping = existingBuilds.drop(numberOfNewBuilds)
     } yield (jobs, existingBuildsAfterDropping, numberOfNewBuilds)
 
+  val jobName = "jobName"
+  val jobUrl  = "jobUrl"
+
+  val validBuildResponseDev =
+    BuildResponse(
+      "validBuildResponseDev".some,
+      218869.some,
+      "123".some,
+      123.some,
+      "SUCCESS".some,
+      1490611944493L.some,
+      "buildurl".some,
+      "builton".some)
+
+  val validBuildResponseOpen =
+    BuildResponse(
+      "validBuildResponseOpen".some,
+      118869.some,
+      "1234".some,
+      1234.some,
+      "SUCCESS".some,
+      1490611944494L.some,
+      "buildurlOpen".some,
+      "builton".some)
+
+  val invalidBuildResponse =
+    BuildResponse(
+      "invalidBuildResponse".some,
+      218869.some,
+      "123".some,
+      123.some,
+      None,
+      1486571225111L.some,
+      "buildurl".some,
+      "builton".some)
+
+  val existingBuildResponse =
+    BuildResponse(
+      "existingBuildResponse".some,
+      218869.some,
+      "124".some,
+      124.some,
+      "SUCCESS".some,
+      1486571225000L.some,
+      "buildurl".some,
+      "builton".some)
+
+  val serviceBuildsDev =
+    List(validBuildResponseDev, invalidBuildResponse, existingBuildResponse)
+
+  val serviceBuildsOpen =
+    List(validBuildResponseOpen, invalidBuildResponse, existingBuildResponse)
+
+  val jobs =
+    List(
+      Job(
+        name      = jobName.some,
+        url       = jobUrl.some,
+        allBuilds = List(validBuildResponseDev, invalidBuildResponse, existingBuildResponse),
+        scm       = serviceGitConfig.some))
+
+  val existingBuild =
+    Build(
+      repositoryName = repoName.some,
+      jobName        = jobName.some,
+      jobUrl         = jobUrl.some,
+      buildNumber    = existingBuildResponse.number,
+      result         = existingBuildResponse.result,
+      timestamp      = existingBuildResponse.timestamp,
+      duration       = existingBuildResponse.duration,
+      buildUrl       = existingBuildResponse.url,
+      builtOn        = existingBuildResponse.builtOn
+    )
+
+  val validBuildDev =
+    Build(
+      repositoryName = repoName.some,
+      jobName        = jobName.some,
+      jobUrl         = jobUrl.some,
+      buildNumber    = validBuildResponseDev.number,
+      result         = validBuildResponseDev.result,
+      timestamp      = validBuildResponseDev.timestamp,
+      duration       = validBuildResponseDev.duration,
+      buildUrl       = validBuildResponseDev.url,
+      builtOn        = validBuildResponseDev.builtOn
+    )
+  val validBuildOpen =
+    Build(
+      repositoryName = repoName.some,
+      jobName        = jobName.some,
+      jobUrl         = jobUrl.some,
+      buildNumber    = validBuildResponseOpen.number,
+      result         = validBuildResponseOpen.result,
+      timestamp      = validBuildResponseOpen.timestamp,
+      duration       = validBuildResponseOpen.duration,
+      buildUrl       = validBuildResponseOpen.url,
+      builtOn        = validBuildResponseOpen.builtOn
+    )
 }

--- a/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsServiceSpec.scala
+++ b/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsServiceSpec.scala
@@ -68,9 +68,7 @@ class RepositoryJobsServiceSpec
 
         Mockito
           .when(connectorCiOpen.getBuilds)
-          .thenReturn(
-            Future.successful(
-              JenkinsJobsResponse(List.empty)))
+          .thenReturn(Future.successful(JenkinsJobsResponse(List.empty)))
 
         And("mongo contains the existing builds")
         repository.bulkAdd(List(existingBuild)).futureValue
@@ -92,9 +90,7 @@ class RepositoryJobsServiceSpec
 
         Mockito
           .when(connectorCiDev.getBuilds)
-          .thenReturn(
-            Future.successful(
-              JenkinsJobsResponse(List.empty)))
+          .thenReturn(Future.successful(JenkinsJobsResponse(List.empty)))
 
         And("mongo contains the existing builds")
         repository.bulkAdd(List(existingBuild)).futureValue
@@ -163,7 +159,6 @@ class RepositoryJobsServiceSpec
           ))))
   }
 
-
   override implicit val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = 5.seconds)
 
@@ -171,9 +166,9 @@ class RepositoryJobsServiceSpec
     override def mongoConnector: MongoConnector = mongoConnectorForTest
   })
 
-  val connectorCiDev: JenkinsCiDevConnector = mock[JenkinsCiDevConnector]
+  val connectorCiDev: JenkinsCiDevConnector   = mock[JenkinsCiDevConnector]
   val connectorCiOpen: JenkinsCiOpenConnector = mock[JenkinsCiOpenConnector]
-  val config: RepositoryJobsConfig = mock[RepositoryJobsConfig]
+  val config: RepositoryJobsConfig            = mock[RepositoryJobsConfig]
 
   val repositoryJobsService = new RepositoryJobsService(repository, connectorCiDev, connectorCiOpen, config)
 


### PR DESCRIPTION
We need build data back from ci-open so we've updated the service to allow jenkins jobs to be harvested from the ci-open endpoint. 

The json data matches up with what's provided on ci-dev so no changes to the model were needed. We've added tests and ran locally and the data is saved to mongo from ci-dev and ci-open.

We'll have to update app-config-build with the correct endpoints before deploying but if this could be reviewed early next week that would be great.

NOTE: app-config-base to be updated and tagged into this PR before it can be merged