### PR TITLE
BDOG-146 Clean up deprecation warnings

### DIFF
--- a/app/uk/gov/hmrc/repositoryjobs/JenkinsConnector.scala
+++ b/app/uk/gov/hmrc/repositoryjobs/JenkinsConnector.scala
@@ -23,12 +23,12 @@ import play.api.libs.json.{JsError, JsSuccess, Json, _}
 import uk.gov.hmrc.http.logging.Authorization
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
 import uk.gov.hmrc.repositoryjobs.JenkinsBuildJobsResponse.flattenJobs
 import uk.gov.hmrc.repositoryjobs.JenkinsConnector.apiTree
 import uk.gov.hmrc.repositoryjobs.JobTree.jobTreeReads
 import uk.gov.hmrc.repositoryjobs.config.RepositoryJobsConfig
-import scala.concurrent.Future
+
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
@@ -46,7 +46,7 @@ trait JenkinsConnector {
 
   def convertJenkinsResponse(jenkinsResponse: JenkinsResponseType): JenkinsJobsResponse
 
-  def getBuilds(implicit hc: HeaderCarrier): Future[JenkinsJobsResponse] = {
+  def getBuilds(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[JenkinsJobsResponse] = {
     val url = host + buildsUrl
 
     val result = http
@@ -85,7 +85,7 @@ object JenkinsConnector {
 }
 
 @Singleton
-class JenkinsCiDevConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)
+class JenkinsCiDevConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)(implicit ec: ExecutionContext)
     extends JenkinsConnector {
   override val host: String            = repositoryJobsConfig.ciDevUrl
   override val http: HttpClient        = httpClient
@@ -97,7 +97,7 @@ class JenkinsCiDevConnector @Inject()(httpClient: HttpClient, repositoryJobsConf
 }
 
 @Singleton
-class JenkinsCiOpenConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)
+class JenkinsCiOpenConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)(implicit ec: ExecutionContext)
     extends JenkinsConnector {
   override val host: String            = repositoryJobsConfig.ciOpenUrl
   override val http: HttpClient        = httpClient
@@ -110,7 +110,7 @@ class JenkinsCiOpenConnector @Inject()(httpClient: HttpClient, repositoryJobsCon
 }
 
 @Singleton
-class JenkinsBuildConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)
+class JenkinsBuildConnector @Inject()(httpClient: HttpClient, repositoryJobsConfig: RepositoryJobsConfig)(implicit ec: ExecutionContext)
     extends JenkinsConnector {
   override val host: String            = repositoryJobsConfig.ciBuildUrl
   override val http: HttpClient        = httpClient

--- a/app/uk/gov/hmrc/repositoryjobs/RepositoryJobsController.scala
+++ b/app/uk/gov/hmrc/repositoryjobs/RepositoryJobsController.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.repositoryjobs
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json.Json
 import play.api.mvc._
-import scala.concurrent.Future
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
-import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
+
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class RepositoryJobsController @Inject()(buildRepository: BuildsRepository, service: RepositoryJobsService)
+class RepositoryJobsController @Inject()(buildRepository: BuildsRepository, service: RepositoryJobsService) (implicit ec: ExecutionContext)
     extends BaseController {
 
   def builds(repositoryName: String) = Action.async { implicit request =>

--- a/test/uk/gov/hmrc/repositoryjobs/JenkinsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/repositoryjobs/JenkinsConnectorSpec.scala
@@ -23,7 +23,7 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Millis, Span}
 import org.scalatest.{Matchers, OptionValues, WordSpec}
 import org.scalatestplus.play.OneAppPerSuite

--- a/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsControllerSpec.scala
+++ b/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsControllerSpec.scala
@@ -20,12 +20,14 @@ import cats.syntax.option._
 import org.mockito.Matchers._
 import org.mockito.Mockito
 import org.mockito.Mockito.when
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class RepositoryJobsControllerSpec extends UnitSpec with MockitoSugar with OneAppPerSuite {
 

--- a/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsServiceSpec.scala
+++ b/test/uk/gov/hmrc/repositoryjobs/RepositoryJobsServiceSpec.scala
@@ -17,33 +17,34 @@
 package uk.gov.hmrc.repositoryjobs
 
 import cats.syntax.option._
+import org.mockito.Matchers.any
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.http.HeaderCarrier
+
 import scala.concurrent.Future
-import org.mockito.Matchers.any
 
 class RepositoryJobsServiceSpec extends WordSpec with Matchers with ScalaFutures with MockitoSugar {
 
   "Update" should {
     "fetch all builds from ci-open and ci-dev and new build and persist them" in {
-      when(connectorCiDev.getBuilds(any()))
+      when(connectorCiDev.getBuilds(any(), any()))
         .thenReturn(
           Future.successful(
             JenkinsJobsResponse(List(
               Job(jobName.some, jobUrl.some, List(validBuildResponseDev), serviceGitConfig.some)
             ))))
 
-      when(connectorCiOpen.getBuilds(any()))
+      when(connectorCiOpen.getBuilds(any(), any()))
         .thenReturn(
           Future.successful(
             JenkinsJobsResponse(List(
               Job(jobName.some, jobUrl.some, List(validBuildResponseOpen), serviceGitConfig.some)
             ))))
 
-      when(connectorCiBuild.getBuilds(any()))
+      when(connectorCiBuild.getBuilds(any(), any()))
         .thenReturn(
           Future.successful(
             JenkinsJobsResponse(


### PR DESCRIPTION

Replacing the deprecated `MdcLoggingExecutionContext` with the global execution context as it is the one used from all other connectors/ controllers etc.